### PR TITLE
fix gettimeofday import

### DIFF
--- a/src/SAIGE_fitGLMM_fast.cpp
+++ b/src/SAIGE_fitGLMM_fast.cpp
@@ -11,6 +11,7 @@
 #include <cmath>
 #include <ctime>// include this header for calculating execution time 
 #include <cassert>
+#include <boost/date_time.hpp> // for gettimeofday and timeval
 using namespace Rcpp;
 using namespace std;
 using namespace RcppParallel;


### PR DESCRIPTION
fixes declaration of gettimeofday

```
SAIGE_fitGLMM_fast.cpp: In function 'double get_wall_time()':
SAIGE_fitGLMM_fast.cpp:1723:9: error: 'gettimeofday' was not declared in this scope
     if (gettimeofday(&time,NULL)){
         ^~~~~~~~~~~~
```